### PR TITLE
Allow alternate `Column` components to be used in the Miller columns

### DIFF
--- a/src/SlamData/Workspace/Card/Open/Component.purs
+++ b/src/SlamData/Workspace/Card/Open/Component.purs
@@ -51,6 +51,7 @@ import SlamData.Workspace.Card.Open.Component.State (State, initialState)
 import SlamData.Workspace.LevelOfDetails as LOD
 import SlamData.Workspace.MillerColumns.BasicItem.Component as MCI
 import SlamData.Workspace.MillerColumns.Column.BasicFilter as MCF
+import SlamData.Workspace.MillerColumns.Column.Component as MCC
 import SlamData.Workspace.MillerColumns.Component as MC
 
 import Utils.Path (AnyPath)
@@ -72,7 +73,7 @@ openComponent =
 
 render ∷ State → HTML
 render state =
-  HH.slot unit (MC.component itemSpec) (pathToColumnData (Left Path.rootDir)) handleMessage
+  HH.slot unit (MC.component columnOptions) (pathToColumnData (Left Path.rootDir)) handleMessage
 
 handleMessage ∷ MC.Message' R.Resource AnyPath Void → Maybe (CC.InnerCardQuery Query Unit)
 handleMessage =
@@ -148,17 +149,16 @@ evalCard = case _ of
       then LOD.Low
       else LOD.High
 
-itemSpec ∷ MCI.BasicColumnOptions R.Resource AnyPath
-itemSpec =
-  { render: MCI.component
-      { label: R.resourceName
-      , render: renderItem
-      }
-  , label: R.resourceName
-  , load
-  , isLeaf: isRight
-  , id: R.getPath
-  }
+columnOptions ∷ MCI.BasicColumnOptions R.Resource AnyPath (Const Void)
+columnOptions =
+  MC.ColumnOptions
+    { renderColumn: MCC.component
+    , renderItem: MCI.component { label: R.resourceName, render: renderItem }
+    , label: R.resourceName
+    , load
+    , isLeaf: isRight
+    , id: R.getPath
+    }
 
 load
   ∷ ∀ r

--- a/src/SlamData/Workspace/Card/Setups/DimensionPicker/Component.purs
+++ b/src/SlamData/Workspace/Card/Setups/DimensionPicker/Component.purs
@@ -27,6 +27,7 @@ import Halogen.Themes.Bootstrap3 as B
 
 import SlamData.Monad (Slam)
 import SlamData.Workspace.MillerColumns.BasicItem.Component as MCI
+import SlamData.Workspace.MillerColumns.Column.Component as MCC
 import SlamData.Workspace.MillerColumns.Component as MC
 import SlamData.Workspace.MillerColumns.TreeData as MCT
 
@@ -61,14 +62,16 @@ type PickerOptions s =
   , isSelectable ∷ s → Boolean
   }
 
-pickerOptionsToColumnOptions ∷ ∀ s. Eq s ⇒ PickerOptions s → MCI.BasicColumnOptions s s
+pickerOptionsToColumnOptions ∷ ∀ s. Ord s ⇒ PickerOptions s → MCI.BasicColumnOptions s s (Const Void)
 pickerOptionsToColumnOptions { label, render, values, isSelectable } =
-  { render: MCI.component { render, label }
-  , label
-  , load: MCT.loadFromTree label values
-  , id
-  , isLeaf: isSelectable
-  }
+  MC.ColumnOptions
+    { renderColumn: MCC.component
+    , renderItem: MCI.component { render, label }
+    , label
+    , load: MCT.loadFromTree label values
+    , id
+    , isLeaf: isSelectable
+    }
 
 labelNode ∷ ∀ s. (s → String) → Either s s → String
 labelNode f = either f f

--- a/src/SlamData/Workspace/MillerColumns/BasicItem/Component.purs
+++ b/src/SlamData/Workspace/MillerColumns/BasicItem/Component.purs
@@ -42,7 +42,7 @@ type ItemSpec a =
 
 type BasicItemHTML = H.ComponentHTML (Const Void)
 
-type BasicColumnOptions a i = MC.ColumnOptions a i Query Void
+type BasicColumnOptions a i g = MC.ColumnOptions a i Query g Void
 
 component
   ∷ ∀ a i

--- a/src/SlamData/Workspace/MillerColumns/Column/Component/Query.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component/Query.purs
@@ -16,6 +16,7 @@ limitations under the License.
 
 module SlamData.Workspace.MillerColumns.Column.Component.Query
   ( Query(..)
+  , Query'
   , Message(..)
   , Message'
   ) where
@@ -35,6 +36,8 @@ data Query a i o b
   | UpdateFilter String b
   | HandleScroll Element b
   | HandleMessage i (ItemMessage' a o) b
+
+type Query' a i o f = Coproduct (Query a i o) f
 
 data Message a i
   = Initialized

--- a/src/SlamData/Workspace/MillerColumns/Column/Component/State.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Component/State.purs
@@ -22,7 +22,7 @@ import Data.List (List(..))
 
 import SlamData.Monad (Slam)
 import SlamData.Workspace.MillerColumns.Column.Options (LoadParams)
-import SlamData.Workspace.MillerColumns.Column.Component.Query (Query)
+import SlamData.Workspace.MillerColumns.Column.Component.Query (Query')
 
 import Halogen.Component.Utils.Debounced (DebounceTrigger(..))
 
@@ -44,7 +44,7 @@ type State a i o =
   , nextOffset ∷ Maybe Int
   , lastLoadParams ∷ Maybe (LoadParams i)
   , tick ∷ Int
-  , filterTrigger ∷ DebounceTrigger (Query a i o) Slam
+  , filterTrigger ∷ DebounceTrigger (Query' a i o (Const Void)) Slam
   }
 
 initialState ∷ ∀ a i o. Maybe a → State a i o

--- a/src/SlamData/Workspace/MillerColumns/Column/Options.purs
+++ b/src/SlamData/Workspace/MillerColumns/Column/Options.purs
@@ -24,14 +24,20 @@ import Halogen as H
 import Halogen.HTML as HH
 
 import SlamData.Monad (Slam)
+import SlamData.Workspace.MillerColumns.Column.Component.Query as Column
 import SlamData.Workspace.MillerColumns.Column.Component.Item (ItemMessage', ItemState)
 
 type LoadParams i = { path ∷ i, filter ∷ String, offset ∷ Maybe Int }
 
-type ColumnOptions a i f o =
-  { render ∷ i → a → H.Component HH.HTML f ItemState (ItemMessage' a o) Slam
-  , label ∷ a → String
-  , load ∷ LoadParams i → Slam { items ∷ L.List a, nextOffset ∷ Maybe Int }
-  , isLeaf ∷ i → Boolean
-  , id ∷ a → i
-  }
+type ColumnComponent a i o g =
+  H.Component HH.HTML (Column.Query' a i o g) (Maybe a) (Column.Message' a i o) Slam
+
+newtype ColumnOptions a i f g o =
+  ColumnOptions
+    { renderColumn ∷ ColumnOptions a i f g o → i → ColumnComponent a i o g
+    , renderItem ∷ i → a → H.Component HH.HTML f ItemState (ItemMessage' a o) Slam
+    , label ∷ a → String
+    , load ∷ LoadParams i → Slam { items ∷ L.List a, nextOffset ∷ Maybe Int }
+    , isLeaf ∷ i → Boolean
+    , id ∷ a → i
+    }

--- a/src/SlamData/Workspace/MillerColumns/Component/State.purs
+++ b/src/SlamData/Workspace/MillerColumns/Component/State.purs
@@ -64,11 +64,11 @@ type ColumnsData a i = i × L.List a
 -- | ]
 -- | ```
 columnPaths
-  ∷ ∀ a i f o
-  . Column.ColumnOptions a i f o
+  ∷ ∀ a i f g o
+  . Column.ColumnOptions a i f g o
   → ColumnsData a i
   → L.List (Int × Maybe a × i)
-columnPaths colSpec (root × selection) =
+columnPaths (Column.ColumnOptions colSpec) (root × selection) =
   let
     paths = (colSpec.id <$> selection) `L.snoc` root
     sels = Nothing : (Just <$> selection)


### PR DESCRIPTION
This will be need to enable the custom actions pinned to the bottom of columns in the structure editor.